### PR TITLE
PHP 5.4 should be required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/mpociot/captainhook"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "illuminate/support": "~5.0"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 5.4 should be required as this is a requirement of ` "illuminate/support": "~5.0"`