### PR TITLE
Adding the ability to assign the tenant_id to the Spark Team

### DIFF
--- a/src/Mpociot/CaptainHook/Http/WebhookController.php
+++ b/src/Mpociot/CaptainHook/Http/WebhookController.php
@@ -27,9 +27,7 @@ class WebhookController extends Controller
      */
     public function all(Request $request)
     {
-        $tenant_id = (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();
-
-        return Webhook::where('tenant_id', $tenant_id)
+        return Webhook::where('tenant_id', $this->getTenantId($request))
             ->with('lastLog')
             ->with('logs')
             ->orderBy('created_at', 'desc')
@@ -87,7 +85,8 @@ class WebhookController extends Controller
     }
 
 
-    protected function getTenantId(Request $request){
+    protected function getTenantId(Request $request)
+    {
         return (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();
     }
 }

--- a/src/Mpociot/CaptainHook/Http/WebhookController.php
+++ b/src/Mpociot/CaptainHook/Http/WebhookController.php
@@ -83,8 +83,7 @@ class WebhookController extends Controller
             ->firstOrFail()
             ->delete();
     }
-
-
+    
     protected function getTenantId(Request $request)
     {
         return (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();

--- a/src/Mpociot/CaptainHook/Http/WebhookController.php
+++ b/src/Mpociot/CaptainHook/Http/WebhookController.php
@@ -83,7 +83,7 @@ class WebhookController extends Controller
             ->firstOrFail()
             ->delete();
     }
-    
+
     protected function getTenantId(Request $request)
     {
         return (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();

--- a/src/Mpociot/CaptainHook/Http/WebhookController.php
+++ b/src/Mpociot/CaptainHook/Http/WebhookController.php
@@ -27,7 +27,9 @@ class WebhookController extends Controller
      */
     public function all(Request $request)
     {
-        return Webhook::where('tenant_id', $request->user()->getKey())
+        $tenant_id = (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();
+
+        return Webhook::where('tenant_id', $tenant_id)
             ->with('lastLog')
             ->with('logs')
             ->orderBy('created_at', 'desc')
@@ -44,7 +46,7 @@ class WebhookController extends Controller
     {
         $hook = Webhook::create([
             'url' => $request->url,
-            'tenant_id' => $request->user()->getKey(),
+            'tenant_id' => $this->getTenantId($request),
             'event' => $request->event,
         ]);
 
@@ -60,7 +62,7 @@ class WebhookController extends Controller
      */
     public function update(UpdateWebhookRequest $request, $webhookId)
     {
-        $webhook = Webhook::where('tenant_id', $request->user()->getKey())
+        $webhook = Webhook::where('tenant_id', $this->getTenantId($request))
             ->where('id', $webhookId)
             ->firstOrFail();
 
@@ -78,9 +80,14 @@ class WebhookController extends Controller
      */
     public function destroy(Request $request, $webhookId)
     {
-        Webhook::where('tenant_id', $request->user()->getKey())
+        Webhook::where('tenant_id', $this->getTenantId($request))
             ->where('id', $webhookId)
             ->firstOrFail()
             ->delete();
+    }
+
+
+    protected function getTenantId(Request $request){
+        return (config('captain_hook.tenant_spark_model', 'User') == 'Team' && isset($request->user()->currentTeam)) ? $request->user()->currentTeam->id : $request->user()->getKey();
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -82,4 +82,22 @@ return [
         'active' => true,
         'storage_quantity' => 50,
     ],
+
+    /*
+   |--------------------------------------------------------------------------
+   | Tenant configuration
+   |--------------------------------------------------------------------------
+   |
+   | The tenant model option allows you to associate the tenant_id
+   | to the Spark Team instead of the User like by default.
+   |
+   | Possible options are: 'User' or 'Team'
+   |
+   | If you use 'User' you should add the following to the 'filter' function:
+   | return $webhook->tenant_id == auth()->user()->getKey();
+   |
+   | If you use 'Team' you should add the following to the 'filter' function:
+   | return $webhook->tenant_id == auth()->user()->currentTeam->id;
+   */
+    'tenant_spark_model' => 'Team',
 ];


### PR DESCRIPTION
The new 'tenant_spark_model' option in the config allows you to assign the tenant_id to the Spark Team instead of the User like is happening by default.