### PR TITLE
Removed deprecated Selfhandling contract

### DIFF
--- a/src/Mpociot/CaptainHook/Jobs/TriggerWebhooksJob.php
+++ b/src/Mpociot/CaptainHook/Jobs/TriggerWebhooksJob.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Support\Str;
 use Mpociot\CaptainHook\WebhookLog;
 use Illuminate\Queue\SerializesModels;
@@ -15,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class TriggerWebhooksJob implements SelfHandling, ShouldQueue
+class TriggerWebhooksJob implements ShouldQueue
 {
     use Queueable, InteractsWithQueue, SerializesModels;
 


### PR DESCRIPTION
[Illuminate/Contacts 5.3](https://github.com/illuminate/contracts/tree/5.3/Bus) no longer has the class `SelfHandling`. Hence Captain Hook breaks in Laravel 5.3.