### PR TITLE
Feature/fixes by pionect

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ be affiliated with the originating application.
 
 ```bash
 php artisan hook:add http://www.myapp.com/hooks/ '\App\Events\PodcastWasPurchased'
-php artisan hook:add http://www.myapp.com/hooks/ 'eloquent.saved \App\User'
+php artisan hook:add http://www.myapp.com/hooks/ 'eloquent.saved: \App\User'
 ```
 
 ```php
@@ -88,7 +88,7 @@ Let's say you want to have a webhook that gets called every time your User model
 
 The event that gets called from Laravel will be:
 
-`eloquent.updated \App\User`
+`eloquent.updated: \App\User`
 
 So this will be the event you want to listen for.
 
@@ -103,7 +103,7 @@ This command takes two arguments:
 - The event name. This could either be one of the `eloquent.*` events, or one of your custom events.
 
 ```bash
-php artisan hook:add http://www.myapp.com/hook/ 'eloquent.saved \App\User'
+php artisan hook:add http://www.myapp.com/hook/ 'eloquent.saved: \App\User'
 ```
 
 You can also add multiple webhooks for the same event, as all configured webhooks will get called asynchronously.

--- a/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
+++ b/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
@@ -158,14 +158,12 @@ class CaptainHookServiceProvider extends ServiceProvider
     {
         // Check if migration ran
         if (Schema::hasTable((new Webhook)->getTable())) {
-            if (!$this->getCache()->has(Webhook::CACHE_KEY)) {
-                $this->getCache()->rememberForever(Webhook::CACHE_KEY, function () {
-                    return Webhook::all();
-                });
-            }
+            return collect($this->getCache()->rememberForever(Webhook::CACHE_KEY, function () {
+                return Webhook::all();
+            }));
         }
 
-        return collect($this->getCache()->get(Webhook::CACHE_KEY));
+        return collect();
     }
 
     /**

--- a/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
+++ b/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
@@ -219,22 +219,10 @@ class CaptainHookServiceProvider extends ServiceProvider
      */
     protected function registerCommands()
     {
-        $this->app['hook.list'] = $this->app->share(function () {
-            return new ListWebhooks();
-        });
-
-        $this->app['hook.add'] = $this->app->share(function () {
-            return new AddWebhook();
-        });
-
-        $this->app['hook.delete'] = $this->app->share(function () {
-            return new DeleteWebhook();
-        });
-
         $this->commands(
-            'hook.list',
-            'hook.add',
-            'hook.delete'
+            ListWebhooks::class,
+            AddWebhook::class,
+            DeleteWebhook::class
         );
     }
 

--- a/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
+++ b/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
@@ -5,6 +5,7 @@ namespace Mpociot\CaptainHook;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Mpociot\CaptainHook\Commands\AddWebhook;
 use Illuminate\Foundation\Bus\DispatchesJobs;
@@ -152,10 +153,13 @@ class CaptainHookServiceProvider extends ServiceProvider
      */
     public function getWebhooks()
     {
-        if (! $this->getCache()->has(Webhook::CACHE_KEY)) {
-            $this->getCache()->rememberForever(Webhook::CACHE_KEY, function () {
-                return Webhook::all();
-            });
+        // Check if migration ran
+        if (Schema::hasTable((new Webhook)->getTable())) {
+            if (!$this->getCache()->has(Webhook::CACHE_KEY)) {
+                $this->getCache()->rememberForever(Webhook::CACHE_KEY, function () {
+                    return Webhook::all();
+                });
+            }
         }
 
         return collect($this->getCache()->get(Webhook::CACHE_KEY));

--- a/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
+++ b/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
@@ -82,10 +82,13 @@ class CaptainHookServiceProvider extends ServiceProvider
     protected function publishMigration()
     {
         $migrations = [
-            __DIR__.'/../../database/2015_10_29_000000_captain_hook_setup_table.php' => database_path('/migrations/'.date('Y_m_d').'_000000_captain_hook_setup_table.php'),
-            __DIR__.'/../../database/2015_10_29_000001_captain_hook_setup_logs_table.php' => database_path('/migrations/'.date('Y_m_d').'_000001_captain_hook_setup_logs_table.php'),
+            __DIR__.'/../../database/2015_10_29_000000_captain_hook_setup_table.php' =>
+                database_path('/migrations/2015_10_29_000000_captain_hook_setup_table.php'),
+            __DIR__.'/../../database/2015_10_29_000001_captain_hook_setup_logs_table.php' =>
+                database_path('/migrations/2015_10_29_000001_captain_hook_setup_logs_table.php'),
         ];
 
+        // To be backwards compatible
         foreach ($migrations as $migration => $toPath) {
             preg_match('/_captain_hook_.*\.php/', $migration, $match);
             $published_migration = glob(database_path('/migrations/*'.$match[0]));

--- a/src/Mpociot/CaptainHook/Webhook.php
+++ b/src/Mpociot/CaptainHook/Webhook.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 /**
  * This file is part of CaptainHook arrrrr.
  *
+ * @property integer id
+ * @property integer tenant_id
+ * @property string  event
+ * @property string  url
  * @license MIT
  */
 class Webhook extends Eloquent

--- a/src/database/2015_10_29_000000_captain_hook_setup_table.php
+++ b/src/database/2015_10_29_000000_captain_hook_setup_table.php
@@ -14,7 +14,7 @@ class CaptainHookSetupTable extends Migration
     {
         Schema::create('webhooks', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('tenant_id')->nullable();
+            $table->integer('tenant_id')->unsigned()->nullable();
             $table->string('url');
             $table->string('event');
             $table->timestamps();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Mpociot\CaptainHook\Commands\AddWebhook;
+use Mpociot\CaptainHook\Commands\DeleteWebhook;
+use Mpociot\CaptainHook\Webhook;
 
 class CommandsTest extends Orchestra\Testbench\TestCase
 {
@@ -16,7 +19,7 @@ class CommandsTest extends Orchestra\Testbench\TestCase
 
     public function testCannotAddWebhookWithoutName()
     {
-        $cmd = m::mock('\\Mpociot\\CaptainHook\\Commands\\AddWebhook[argument,error]');
+        $cmd = m::mock(AddWebhook::class . '[argument,error]');
 
         $cmd->shouldReceive('error')
             ->once()
@@ -36,7 +39,7 @@ class CommandsTest extends Orchestra\Testbench\TestCase
 
     public function testCanAddWebhook()
     {
-        $cmd = m::mock('\\Mpociot\\CaptainHook\\Commands\\AddWebhook[argument,info]');
+        $cmd = m::mock(AddWebhook::class . '[argument,info]');
 
         $cmd->shouldReceive('argument')
             ->with('url')
@@ -59,11 +62,11 @@ class CommandsTest extends Orchestra\Testbench\TestCase
 
     public function testCannotDeleteWebhookWithWrongID()
     {
-        $webhook = \Mpociot\CaptainHook\Webhook::create([
+        Webhook::create([
             'url' => 'http://foo.baz',
             'event' => 'DeleteWebhook',
         ]);
-        $cmd = m::mock('\\Mpociot\\CaptainHook\\Commands\\DeleteWebhook[argument,error]');
+        $cmd = m::mock(DeleteWebhook::class . '[argument,error]');
 
         $cmd->shouldReceive('argument')
             ->with('id')
@@ -82,11 +85,11 @@ class CommandsTest extends Orchestra\Testbench\TestCase
 
     public function testCanDeleteWebhook()
     {
-        $webhook = \Mpociot\CaptainHook\Webhook::create([
+        $webhook = Webhook::create([
            'url' => 'http://foo.baz',
            'event' => 'DeleteWebhook',
         ]);
-        $cmd = m::mock('\\Mpociot\\CaptainHook\\Commands\\DeleteWebhook[argument,info]');
+        $cmd = m::mock(DeleteWebhook::class . '[argument,info]');
 
         $cmd->shouldReceive('argument')
             ->with('id')


### PR DESCRIPTION
Hey,

I changed the following things:

- Check if migrations ran in service provider before querying the database. 
      If the package is added by a deploy service, it fails because it tries to fetch webhooks before the migrations are run.
- Remove dynamic migration dates.
      This is because I needed to change the migration in an other package in stead of the underlying Laravel project. It's impossible to override a migration in an other package if "vendor:publish" is run by a deploy service and the migration name is unknown. (the files are copied after all the service providers have been triggered, so the check if the migration already exists doesn't work in this case)
- made tenant_id unsigned
      This is done so I can set a foreign key to another table.
- add missing : to eloquent events in README
      The webhooks weren't triggering because I missed a : in the event name.

Hope I provided enough info and you accept this pull request! :)