### PR TITLE
Fix #43

### DIFF
--- a/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
+++ b/src/Mpociot/CaptainHook/CaptainHookServiceProvider.php
@@ -126,7 +126,7 @@ class CaptainHookServiceProvider extends ServiceProvider
     protected function registerEventListeners()
     {
         foreach ($this->listeners as $eventName) {
-            $this->app['events']->listen($eventName, [$this, 'handleEvent']);
+            $this->app['events']->listen($eventName . '*', [$this, 'handleEvent']);
         }
     }
 
@@ -201,11 +201,11 @@ class CaptainHookServiceProvider extends ServiceProvider
     /**
      * Event listener.
      *
+     * @param $eventName
      * @param $eventData
      */
-    public function handleEvent($eventData)
+    public function handleEvent($eventName, $eventData)
     {
-        $eventName = Event::firing();
         $webhooks = $this->getWebhooks()->where('event', $eventName);
         $webhooks = $webhooks->filter($this->config->get('captain_hook.filter', null));
 


### PR DESCRIPTION
Our take on Laravel 5.4 compatibility.

By using a wildcard in the event name Laravel will give us the event name in the event listener so we don’t have to retrieve the name from elsewhere.